### PR TITLE
Resolve Error in /register Endpoint

### DIFF
--- a/routes/auth.js
+++ b/routes/auth.js
@@ -11,7 +11,7 @@ const HttpError = require("../utils/HttpError");
 // Joi
 const Joi = require("joi");
 // DB (Knex)
-const { insertUserTransaction } = require("../db/db-auth");
+const { insertUser } = require("../db/db-auth");
 
 const authRouter = new Router();
 


### PR DESCRIPTION
This pull request fixes the `insertUser is not defined` error when calling the `/register` endpoint.